### PR TITLE
adds syntax-color-function and syntax-color-method

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -24,3 +24,7 @@
 @syntax-color-added: #529b2f;
 @syntax-color-modified: #E6DB74;
 @syntax-color-removed: #F92672;
+
+// For language entity colors
+@syntax-color-function: #99FF00;
+@syntax-color-method: @syntax-color-function;


### PR DESCRIPTION
Seems the `syntax-variables.less` file is missing some required variables. At least a had [this problem](https://github.com/smockle/colorful-json/issues/1) because was missing the `@syntax-color-function` and since the `monokai-seti` has it owns `syntax-variables.less` file it means is overriding the default file and should include all the existing variables from the [original file](https://github.com/atom/atom/blob/master/static/variables/syntax-variables.less).

Since I am not sure about which are the right colors for each variable I have include only the variables I needed. But would be awesome if someone could include the rest of  them.

